### PR TITLE
Respect DESTDIR parameter to `make install`

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -30,5 +30,5 @@ noinst_HEADERS = \
 	endian.h BCB_endian.h
 
 install-data-local:
-	$(mkinstalldirs) $(includedir)
-	$(INSTALL_DATA) $(srcdir)/MathLib.h $(includedir)
+	$(mkinstalldirs) "$(DESTDIR)/$(includedir)"
+	$(INSTALL_DATA) $(srcdir)/MathLib.h "$(DESTDIR)/$(includedir)"

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -737,8 +737,8 @@ uninstall-am: uninstall-includeHEADERS uninstall-libLTLIBRARIES
 
 
 install-data-local:
-	$(mkinstalldirs) $(includedir)
-	$(INSTALL_DATA) $(srcdir)/MathLib.h $(includedir)
+	$(mkinstalldirs) "$(DESTDIR)$(includedir)"
+	$(INSTALL_DATA) $(srcdir)/MathLib.h "$(DESTDIR)$(includedir)"
 
 # Tell versions [3.59,3.63) of GNU make to not export all variables.
 # Otherwise a system limit (for SysV at least) may be exceeded.


### PR DESCRIPTION
Previously, the parameter was ignored in some cases. Specifically, when installing the `MathLib.h` header file. This commit makes the generated Makefiles respect the `DESTDIR` parameter.

This is particularly needed for packaging the library.